### PR TITLE
fix: correct regex for ignore_patterns

### DIFF
--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -40,7 +40,7 @@ grumphp:
         - /^config\/(.*)/
         - /drush
         - /web/robots.txt
-        - /web/sites/default
+        - /^web\/sites\/default/
         - bower_components
         - node_modules
         - /vendor
@@ -74,7 +74,7 @@ grumphp:
         - /^config\/(.*)/
         - /drush
         - /web/robots.txt
-        - /web/sites/default
+        - /^web\/sites\/default/
         - bower_components
         - node_modules
         - /vendor

--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -34,9 +34,9 @@ grumphp:
       standard:
         - phpcs.xml.dist
       ignore_patterns:
-        - .github
-        - .gitlab
-        - .ddev
+        - /\.github
+        - /\.gitlab
+        - /\.ddev
         - /config
         - /drush
         - /web/robots.txt
@@ -68,9 +68,9 @@ grumphp:
     phpstan:
       configuration: phpstan.neon.dist
       ignore_patterns:
-        - .github
-        - .gitlab
-        - .ddev
+        - /\.github
+        - /\.gitlab
+        - /\.ddev
         - /config
         - /drush
         - /web/robots.txt

--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -37,7 +37,7 @@ grumphp:
         - /\.github
         - /\.gitlab
         - /\.ddev
-        - /config
+        - /^config\/(.*)/
         - /drush
         - /web/robots.txt
         - /web/sites/default
@@ -71,7 +71,7 @@ grumphp:
         - /\.github
         - /\.gitlab
         - /\.ddev
-        - /config
+        - /^config\/(.*)/
         - /drush
         - /web/robots.txt
         - /web/sites/default


### PR DESCRIPTION
The ignore_patterns are defined as regex expressions, so special characters must be escaped properly to avoid unintended matches. This update ensures that the regex is corrected to match only the intended directories.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
