### PR TITLE
Remove Unnecessary or Git-Ignored Patterns

### DIFF
--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -8,7 +8,12 @@ grumphp:
   tasks:
     phplint:
       exclude:
+        - web/core
+        - web/modules/contrib
+        - web/themes/contrib
+        - web/profiles/contrib
         - web/sites/default
+        - vendor
       triggered_by:
         - php
         - module

--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -63,7 +63,6 @@ grumphp:
         - /\.ddev
         - /^config\/(.*)/
         - /drush
-        - /web/robots.txt
         - /^web\/sites\/default/
         - bower_components
         - node_modules

--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -34,7 +34,6 @@ grumphp:
         - /\.ddev
         - /^config\/(.*)/
         - /drush
-        - /web/robots.txt
         - /^web\/sites\/default/
         - bower_components
         - node_modules
@@ -49,7 +48,6 @@ grumphp:
         - theme
         - css
         - info
-        - txt
     phpmd:
       whitelist_patterns:
         - /^web\/modules\/custom\/(.*)/

--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -8,12 +8,7 @@ grumphp:
   tasks:
     phplint:
       exclude:
-        - web/core
-        - web/modules/contrib
-        - web/themes/contrib
-        - web/profiles/contrib
         - web/sites/default
-        - vendor
       triggered_by:
         - php
         - module

--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -64,9 +64,6 @@ grumphp:
         - /^config\/(.*)/
         - /drush
         - /^web\/sites\/default/
-        - bower_components
-        - node_modules
-        - /vendor
       triggered_by:
         - php
         - module

--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -35,9 +35,6 @@ grumphp:
         - /^config\/(.*)/
         - /drush
         - /^web\/sites\/default/
-        - bower_components
-        - node_modules
-        - /vendor
       triggered_by:
         - php
         - module


### PR DESCRIPTION
GrumPHP automatically excludes Git-ignored directories by default. Therefore, it is safe to remove those directories from the ignore_patterns configuration

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"fix-ignore-patterns-regex","parentHead":"bfaddc9c60becc80da39e8c824cd71b177359936","parentPull":1,"trunk":"main"}
```
-->
